### PR TITLE
Rename RUN_TEST to match existing jenkins job config

### DIFF
--- a/vars/buildKodi.groovy
+++ b/vars/buildKodi.groovy
@@ -51,6 +51,8 @@ def call(Map buildParams = [:]) {
     env.RUN_TESTS = buildParams.containsKey('RUN_TESTS') ? buildParams.RUN_TESTS : params.RUN_TESTS
     def qualityGateThreshold = buildParams.containsKey('qualityGateThreshold') ? buildParams.qualityGateThreshold : 1
 
+    def FILTER_TESTS = buildParams.containsKey('FILTER_TESTS') ? '--gtest_filter=' + buildParams.FILTER_TESTS : ''
+
     // Globals
     def verifyHash = ''
     def os = ''
@@ -293,7 +295,7 @@ def call(Map buildParams = [:]) {
                       cd $WORKSPACE/build
                       make -j$BUILDTHREADS VERBOSE=1 kodi-test
                       if [ "$Configuration" != "Coverage" ]; then
-                        cd $WORKSPACE;build/kodi-test --gtest_output=xml:gtestresults.xml
+                        cd $WORKSPACE;build/kodi-test --gtest_output=xml:gtestresults.xml $FILTER_TESTS
                       else
                         cd $WORKSPACE/build;GTEST_OUTPUT="xml:$WORKSPACE/gtestresults.xml" make coverage
                       fi

--- a/vars/buildKodi.groovy
+++ b/vars/buildKodi.groovy
@@ -48,6 +48,7 @@ def call(Map buildParams = [:]) {
     env.BUILD_CAUSE = env.BUILD_CAUSE ?: 'manual'
     env.UPSTREAM_BUILD_CAUSE = env.UPSTREAM_BUILD_CAUSE ?: 'none'
     env.ADDONS = buildParams.containsKey('addons') ? buildParams.addons : params.ADDONS
+    env.RUN_TESTS = buildParams.containsKey('RUN_TESTS') ? buildParams.RUN_TESTS : params.RUN_TESTS
     def qualityGateThreshold = buildParams.containsKey('qualityGateThreshold') ? buildParams.qualityGateThreshold : 1
 
     // Globals
@@ -80,7 +81,7 @@ def call(Map buildParams = [:]) {
             choice(name: 'NDK', choices: ndkChoices, description: 'Android only: android NDK')
             booleanParam(name: 'BUILD_BINARY_ADDONS', defaultValue: true, description: 'Whether binary addons should be built during or not.')
             string(name: 'ADDONS', defaultValue: defaultAddons, description: 'Which binary addons should be built.')
-            booleanParam(name: 'RUN_TEST', defaultValue: false, description: 'Turn this on if you want to build and run the xbmc unit tests based on  gtest.')
+            booleanParam(name: 'RUN_TESTS', defaultValue: false, description: 'Turn this on if you want to build and run the xbmc unit tests based on  gtest.')
             booleanParam(name: 'UPLOAD_RESULT', defaultValue: false, description: 'Whether the resulting builds should be uploaded to test-builds')
             string(name: 'PR', defaultValue: null, description: 'Pull Request to build. Overrides Revision, empty for normal build')
         }
@@ -286,7 +287,7 @@ def call(Map buildParams = [:]) {
             }
 
             stage('Run tests') {
-                when { equals expected: true, actual: params.RUN_TEST }
+                when { equals expected: true, actual: env.RUN_TESTS }
                 steps {
                     sh '''
                       cd $WORKSPACE/build


### PR DESCRIPTION
Jenkins jobs are all setup with the env var RUN_TESTS

Intent is just to change the pipeline script to match, rather than change the dozen+ jobs to match the pipeline.

Not sure if the env.RUN_TESTS being set is correct. couldnt test on jenkins. still cant work out how to run a script that was originally called from a lib.

I did a test run on the docker build with a job changed to RUN_TEST (actually just added it in addition to the existing RUN_TESTS), and we get the following like we did on the leaseweb builder (https://jenkins.kodi.tv/job/linux-docker/579/console)

```
[----------] Global test environment tear-down
[==========] 1130 tests from 153 test suites ran. (4071 ms total)
[  PASSED  ] 1129 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] TestNetwork.PingHost

 1 FAILED TEST
  YOU HAVE 4 DISABLED TESTS
```

So ive introduced a build param for FILTER_TEST to be able to supply a filter test

the following would have to be added for the linux test jobs to disable that test. We did this already for old style build step jobs on the leaseweb builder, and infra issue for tracking was added https://github.com/xbmc/infrastructure/issues/60

```
FILTER_TESTS=-TestNetwork.PingHost
```