### PR TITLE
Further test fixes

### DIFF
--- a/vars/buildKodi.groovy
+++ b/vars/buildKodi.groovy
@@ -289,7 +289,7 @@ def call(Map buildParams = [:]) {
             }
 
             stage('Run tests') {
-                when { equals expected: true, actual: env.RUN_TESTS }
+                when { equals expected: 'true', actual: env.RUN_TESTS }
                 steps {
                     sh '''
                       cd $WORKSPACE/build

--- a/vars/buildKodi.groovy
+++ b/vars/buildKodi.groovy
@@ -51,7 +51,7 @@ def call(Map buildParams = [:]) {
     env.RUN_TESTS = buildParams.containsKey('RUN_TESTS') ? buildParams.RUN_TESTS : params.RUN_TESTS
     def qualityGateThreshold = buildParams.containsKey('qualityGateThreshold') ? buildParams.qualityGateThreshold : 1
 
-    def FILTER_TESTS = buildParams.containsKey('FILTER_TESTS') ? '--gtest_filter=' + buildParams.FILTER_TESTS : ''
+    env.FILTER_TESTS = buildParams.containsKey('FILTER_TESTS') ? '--gtest_filter=' + buildParams.FILTER_TESTS : ''
 
     // Globals
     def verifyHash = ''


### PR DESCRIPTION
Need to set env for FILTER_TESTS to pass through to shell script stage step
while expected value needs to be in ``

Have added my repo to jenkins for quicker testing of the library.
The following is a test of linux-docker job with these changes. Works at single job level, Im hoping meta jobs pass the right things through for tests, we'll see, haha

https://jenkins.kodi.tv/job/Test_linux/20/console

