### PR TITLE
Conditionatlly run Addonstatus badge check

### DIFF
--- a/vars/buildKodi.groovy
+++ b/vars/buildKodi.groovy
@@ -48,6 +48,7 @@ def call(Map buildParams = [:]) {
     env.BUILD_CAUSE = env.BUILD_CAUSE ?: 'manual'
     env.UPSTREAM_BUILD_CAUSE = env.UPSTREAM_BUILD_CAUSE ?: 'none'
     env.ADDONS = buildParams.containsKey('addons') ? buildParams.addons : params.ADDONS
+    env.BUILD_BINARY_ADDONS = params.BUILD_BINARY_ADDONS
     env.RUN_TESTS = buildParams.containsKey('RUN_TESTS') ? buildParams.RUN_TESTS : params.RUN_TESTS
     def qualityGateThreshold = buildParams.containsKey('qualityGateThreshold') ? buildParams.qualityGateThreshold : 1
 
@@ -391,7 +392,9 @@ def call(Map buildParams = [:]) {
         post {
             always {
                 script {
-                    addonStatusBadge(env.WORKSPACE + '/cmake/addons/.success', env.WORKSPACE + '/cmake/addons/.failure')
+                    if(env.BUILD_BINARY_ADDONS == 'true') {
+                      addonStatusBadge(env.WORKSPACE + '/cmake/addons/.success', env.WORKSPACE + '/cmake/addons/.failure')
+                    }
                 }
                 recordIssues filters: [includeFile('xbmc/.*')], qualityGates: [[threshold: qualityGateThreshold, type: 'TOTAL', unstable: false]], tools: [clang()]
                 addEmbeddableBadgeConfiguration(id: '$BUILD_TAG')


### PR DESCRIPTION
Currently the Addonstatus badge check is run unconditionally.
With this, we see the following occur under specific circumstances. A job will have the ! warning and the warning is due to the addon failed. However in PR builds addons arent built generally

https://jenkins.kodi.tv/job/BuildMulti-PR/31116/

Another example with a current log that shows a larger, but related issue (not for long no doubt due to our log retention) https://jenkins.kodi.tv/job/android-arm-docker/7620/consoleFull
```
[Pipeline] { (Build binary addons)
Stage "Build binary addons" skipped due to when conditional
[Pipeline] getContext
<snip>
#------------- BINARY ADDON STATUS ----------------#
[Pipeline] fileExists
[Pipeline] readFile
[Pipeline] echo
addonsSucceeded: peripheral.joystick

[Pipeline] fileExists
[Pipeline] echo ([hide](https://jenkins.kodi.tv/job/android-arm-docker/7620/consoleFull#))
addonsFailed: none
[Pipeline] echo
#--------------------------------------------------#
```

This actually highlights another issue, the fact the addon dir isnt cleaned. It retains from previous build jobs, and therefore the addon status check is pulling info not relevant to the actual job being run.

The intent of this PR is to not run the badge check if addons werent built in this run. We will most likely want to also clean addon dirs in another PR to stop this "contamination" across runs.

Test executions of this change
Addons disabled: https://jenkins.kodi.tv/view/All/job/Test_linux/44/
Addons enabled: https://jenkins.kodi.tv/view/All/job/Test_linux/45/