### PR TITLE
recordIssues exclude tools/depends

### DIFF
--- a/vars/buildKodi.groovy
+++ b/vars/buildKodi.groovy
@@ -393,7 +393,7 @@ def call(Map buildParams = [:]) {
                 script {
                     addonStatusBadge(env.WORKSPACE + '/cmake/addons/.success', env.WORKSPACE + '/cmake/addons/.failure')
                 }
-                recordIssues filters: [includeFile('xbmc/.*')], qualityGates: [[threshold: qualityGateThreshold, type: 'TOTAL', unstable: false]], tools: [clang()]
+                recordIssues filters: [includeFile('xbmc/.*'), excludeFile('tools/depends/.*')], qualityGates: [[threshold: qualityGateThreshold, type: 'TOTAL', unstable: false]], tools: [clang()]
                 addEmbeddableBadgeConfiguration(id: '$BUILD_TAG')
             }
         }


### PR DESCRIPTION
We currently intermittently receive warning gate failures due to the following

```
    [Clang] [-ERROR-] Can't create fingerprints for some files:
    [Clang] [-ERROR-] - '/home/jenkins/jenkins-root/workspace/android-x86-docker@2/tools/depends/target/dummy-libxbmc/checking for sys/types.h... configure.ac' file not found
    [Clang] [-ERROR-] - '/home/jenkins/jenkins-root/workspace/android-x86-docker@2/tools/depends/target/dummy-libxbmc/configure.ac' file not found
    [Clang] [-ERROR-] - '/home/jenkins/jenkins-root/workspace/android-x86-docker@2/tools/depends/target/dummy-libxbmc/configure.ac' file not found
    [Clang] [-ERROR-] - '/home/jenkins/jenkins-root/workspace/android-x86-docker@2/tools/depends/target/dummy-libxbmc/configure.ac' file not found
    [Clang] [-ERROR-] - '/home/jenkins/jenkins-root/workspace/android-x86-docker@2/tools/depends/target/dummy-libxbmc/configure.ac' file not found
    The recommended git tool is: NONE
     > git rev-parse HEAD^{commit} # timeout=10
    using credential github-app-xbmc
    The recommended git tool is: NONE
    using credential github-app-xbmc
    [Clang] Reference build recorder is not configured
    [Clang] No valid reference build found
    [Clang] All reported issues will be considered outstanding
    [Clang] Evaluating quality gates
    [Clang] -> Some quality gates have been missed: overall result is FAILURE
    [Clang] -> Details for each quality gate:
    [Clang]    - [Total (any severity)]: ≪Failed≫ - (Actual value: 5, Quality gate: 1.00)
    [Clang] Health report is disabled - skipping
```

The core issue is a parsing failure in the warning plugin, however the intent of our includeFile was to filter out anything not in the xbmc tree. Unfortunately on android we have dummy-libxbmc which matches the includeFile filter
Exclude tools/depends to remove dummy-libxbmc from being seen as valid inclusion.

As best i can tell, the plugin will checks all filters, therefore it should correctly exclude anything in tools/depends, even though it passes the first include filter

Snippet from Jenkins config setup for warning filters
```
Issue filters
Filters
Issues will be matched with all the specified filters. If no filter is defined, then all issues will be published. Filters with empty regular expression will be ignored.
```